### PR TITLE
Fix non-streaming execute() in GgufChatModel

### DIFF
--- a/llm_gguf.py
+++ b/llm_gguf.py
@@ -270,32 +270,8 @@ class GgufChatModel(llm.Model):
 
         if not stream:
             model = self.get_model()
-            completion = model.create_chat_completion(
-                messages=messages,
-                tools=[
-                    {
-                        "type": "function",
-                        "function": {
-                            "name": "search_blog",
-                            "description": "Search for posts on the blog.",
-                            "parameters": {
-                                "type": "object",
-                                "properties": {
-                                    "query": {
-                                        "type": "string",
-                                        "description": "Search query, keywords only",
-                                    }
-                                },
-                                "required": ["query"],
-                                "additionalProperties": False,
-                            },
-                        },
-                    }
-                ],
-                tool_choice="auto",
-            )
-            breakpoint()
-            return [completion["choices"][0]["text"]]
+            completion = model.create_chat_completion(messages=messages)
+            return [completion["choices"][0]["message"]["content"]]
 
         # Streaming
         model = self.get_model()


### PR DESCRIPTION
Fixes the non-streaming (`stream=False`) path in `GgufChatModel.execute()`, reported in #16.

That branch was placeholder/debug code:

- it dropped into `pdb` via a stray `breakpoint()` (the pdb prompt reported in simonw/llm#1422),
- it attached a hardcoded `search_blog` function tool to every non-streaming request, and
- it then read the reply from `completion["choices"][0]["text"]`, a key that `llama_cpp`'s `create_chat_completion()` does not return (chat responses put the text under `choices[0].message.content`).

This makes the non-streaming branch mirror the streaming one: call `create_chat_completion(messages=messages)` with no injected tool, and return the content from the message.

```python
if not stream:
    model = self.get_model()
    completion = model.create_chat_completion(messages=messages)
    return [completion["choices"][0]["message"]["content"]]
```

Closes #16
Refs simonw/llm#1422

This supersedes the original one-line version of this PR, which only removed the `breakpoint()`.

Note: I verified this against the `llama_cpp` chat-completion response shape and the existing streaming branch in this same file; I was not able to run a real GGUF model locally.
