### PR TITLE
Add unregister-model and unregister-embed-model commands

### DIFF
--- a/llm_gguf.py
+++ b/llm_gguf.py
@@ -184,6 +184,32 @@ def register_commands(cli):
         models_file.write_text(json.dumps(models, indent=2))
 
     @gguf.command()
+    @click.argument("model_id")
+    def unregister_model(model_id):
+        "Remove a registered GGUF model"
+        models_file = _ensure_models_file()
+        models = json.loads(models_file.read_text())
+        if model_id not in models:
+            raise click.ClickException(
+                "Model '{}' is not registered".format(model_id)
+            )
+        del models[model_id]
+        models_file.write_text(json.dumps(models, indent=2))
+
+    @gguf.command()
+    @click.argument("model_id")
+    def unregister_embed_model(model_id):
+        "Remove a registered GGUF embedding model"
+        models_file = _ensure_embed_models_file()
+        models = json.loads(models_file.read_text())
+        if model_id not in models:
+            raise click.ClickException(
+                "Embedding model '{}' is not registered".format(model_id)
+            )
+        del models[model_id]
+        models_file.write_text(json.dumps(models, indent=2))
+
+    @gguf.command()
     def models():
         "List registered GGUF models"
         models_file = _ensure_models_file()

--- a/tests/test_gguf.py
+++ b/tests/test_gguf.py
@@ -35,3 +35,45 @@ def test_embed_with_tiny_model(monkeypatch):
     except json.JSONDecodeError:
         assert False, result2.output
     assert len(vector) == 384
+
+
+def test_register_and_unregister_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_USER_PATH", str(tmp_path))
+    runner = CliRunner()
+    # register-model needs a file that exists; contents are irrelevant here
+    dummy = tmp_path / "fake.gguf"
+    dummy.write_bytes(b"not a real model")
+    models_file = tmp_path / "gguf" / "models.json"
+
+    result = runner.invoke(cli, ["gguf", "register-model", "fake-model", str(dummy)])
+    assert result.exit_code == 0, result.output
+    assert "fake-model" in json.loads(models_file.read_text())
+
+    result2 = runner.invoke(cli, ["gguf", "unregister-model", "fake-model"])
+    assert result2.exit_code == 0, result2.output
+    assert "fake-model" not in json.loads(models_file.read_text())
+
+    # Unregistering again should fail cleanly with a non-zero exit code
+    result3 = runner.invoke(cli, ["gguf", "unregister-model", "fake-model"])
+    assert result3.exit_code != 0
+
+
+def test_register_and_unregister_embed_model(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_USER_PATH", str(tmp_path))
+    runner = CliRunner()
+    dummy = tmp_path / "fake-embed.gguf"
+    dummy.write_bytes(b"not a real model")
+    models_file = tmp_path / "gguf" / "embed-models.json"
+
+    result = runner.invoke(
+        cli, ["gguf", "register-embed-model", "fake-embed", str(dummy)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "fake-embed" in json.loads(models_file.read_text())
+
+    result2 = runner.invoke(cli, ["gguf", "unregister-embed-model", "fake-embed"])
+    assert result2.exit_code == 0, result2.output
+    assert "fake-embed" not in json.loads(models_file.read_text())
+
+    result3 = runner.invoke(cli, ["gguf", "unregister-embed-model", "fake-embed"])
+    assert result3.exit_code != 0


### PR DESCRIPTION
Implements the `unregister-model` / `unregister-embed-model` request in #12.

Adds two commands that mirror the existing `register-model` and `register-embed-model`:

```
llm gguf unregister-model <model_id>
llm gguf unregister-embed-model <model_id>
```

Each loads the relevant JSON file (`models.json` / `embed-models.json`), removes the entry, and writes it back. If the model id is not registered it raises a `click.ClickException` so the command exits non-zero with a clear message instead of silently doing nothing.

The command names come from click's normal underscore-to-hyphen conversion of the function names, matching the existing `register-model` style.

I verified the file parses with `python -m py_compile`. I was not able to run a live GGUF model locally, so I have not exercised the commands end to end against a real registration; the logic is a direct inverse of the existing register commands in the same file.

Happy to add README docs and/or tests in this PR if you'd like them included.

Closes #12
